### PR TITLE
Fix tearing when entering Accelerated Compositing Mode

### DIFF
--- a/Source/WebCore/platform/gtk/GtkUtilities.cpp
+++ b/Source/WebCore/platform/gtk/GtkUtilities.cpp
@@ -51,7 +51,7 @@ IntPoint convertWidgetPointToScreenPoint(GtkWidget* widget, const IntPoint& poin
 
 bool widgetIsOnscreenToplevelWindow(GtkWidget* widget)
 {
-    return gtk_widget_is_toplevel(widget) && GTK_IS_WINDOW(widget) && !GTK_IS_OFFSCREEN_WINDOW(widget);
+    return widget && gtk_widget_is_toplevel(widget) && GTK_IS_WINDOW(widget) && !GTK_IS_OFFSCREEN_WINDOW(widget);
 }
 
 #if ENABLE(DEVELOPER_MODE)

--- a/Source/WebKit2/UIProcess/API/gtk/WebKitWebViewBase.cpp
+++ b/Source/WebKit2/UIProcess/API/gtk/WebKitWebViewBase.cpp
@@ -183,6 +183,7 @@ struct _WebKitWebViewBasePrivate {
     unsigned long toplevelFocusInEventID;
     unsigned long toplevelFocusOutEventID;
     unsigned long toplevelWindowStateEventID;
+    unsigned long toplevelWindowRealizedID;
 
     // View State.
     ViewState::Flags viewState;
@@ -272,6 +273,17 @@ static gboolean toplevelWindowStateEvent(GtkWidget*, GdkEventWindowState* event,
     return FALSE;
 }
 
+static void toplevelWindowRealized(WebKitWebViewBase* webViewBase)
+{
+    gtk_widget_realize(GTK_WIDGET(webViewBase));
+
+    WebKitWebViewBasePrivate* priv = webViewBase->priv;
+    if (priv->toplevelWindowRealizedID) {
+        g_signal_handler_disconnect(priv->toplevelOnScreenWindow, priv->toplevelWindowRealizedID);
+        priv->toplevelWindowRealizedID = 0;
+    }
+}
+
 static void webkitWebViewBaseSetToplevelOnScreenWindow(WebKitWebViewBase* webViewBase, GtkWindow* window)
 {
     WebKitWebViewBasePrivate* priv = webViewBase->priv;
@@ -289,6 +301,10 @@ static void webkitWebViewBaseSetToplevelOnScreenWindow(WebKitWebViewBase* webVie
     if (priv->toplevelWindowStateEventID) {
         g_signal_handler_disconnect(priv->toplevelOnScreenWindow, priv->toplevelWindowStateEventID);
         priv->toplevelWindowStateEventID = 0;
+    }
+    if (priv->toplevelWindowRealizedID) {
+        g_signal_handler_disconnect(priv->toplevelOnScreenWindow, priv->toplevelWindowRealizedID);
+        priv->toplevelWindowRealizedID = 0;
     }
 
     priv->toplevelOnScreenWindow = window;
@@ -317,7 +333,11 @@ static void webkitWebViewBaseSetToplevelOnScreenWindow(WebKitWebViewBase* webVie
                          G_CALLBACK(toplevelWindowFocusOutEvent), webViewBase);
     priv->toplevelWindowStateEventID =
         g_signal_connect(priv->toplevelOnScreenWindow, "window-state-event", G_CALLBACK(toplevelWindowStateEvent), webViewBase);
-    gtk_widget_realize(GTK_WIDGET(webViewBase));
+
+    if (gtk_widget_get_realized(GTK_WIDGET(window)))
+        gtk_widget_realize(GTK_WIDGET(webViewBase));
+    else
+        priv->toplevelWindowRealizedID = g_signal_connect_swapped(window, "realize", G_CALLBACK(toplevelWindowRealized), webViewBase);
 }
 
 static void webkitWebViewBaseRealize(GtkWidget* widget)

--- a/Source/WebKit2/UIProcess/API/gtk/WebKitWebViewBasePrivate.h
+++ b/Source/WebKit2/UIProcess/API/gtk/WebKitWebViewBasePrivate.h
@@ -59,7 +59,6 @@ bool webkitWebViewBaseIsInWindowActive(WebKitWebViewBase*);
 bool webkitWebViewBaseIsFocused(WebKitWebViewBase*);
 bool webkitWebViewBaseIsVisible(WebKitWebViewBase*);
 bool webkitWebViewBaseIsInWindow(WebKitWebViewBase*);
-bool webkitWebViewBaseIsWindowVisible(WebKitWebViewBase*);
 
 typedef void (*WebKitWebViewBaseDownloadRequestHandler) (WebKitWebViewBase*, WebKit::DownloadProxy*);
 void webkitWebViewBaseSetDownloadRequestHandler(WebKitWebViewBase*, WebKitWebViewBaseDownloadRequestHandler);

--- a/Source/WebKit2/UIProcess/cairo/BackingStoreCairo.cpp
+++ b/Source/WebKit2/UIProcess/cairo/BackingStoreCairo.cpp
@@ -67,9 +67,7 @@ std::unique_ptr<BackingStoreBackendCairo> BackingStore::createBackend()
     scaledSize.scale(m_deviceScaleFactor);
 
 #if PLATFORM(GTK)
-    GtkWidget* viewWidget = m_webPageProxy.viewWidget();
-    gtk_widget_realize(viewWidget);
-    RefPtr<cairo_surface_t> surface = adoptRef(gdk_window_create_similar_surface(gtk_widget_get_window(viewWidget),
+    RefPtr<cairo_surface_t> surface = adoptRef(gdk_window_create_similar_surface(gtk_widget_get_window(m_webPageProxy.viewWidget()),
         CAIRO_CONTENT_COLOR_ALPHA, scaledSize.width(), scaledSize.height()));
 #else
     RefPtr<cairo_surface_t> surface = adoptRef(cairo_image_surface_create(CAIRO_FORMAT_ARGB32, scaledSize.width(), scaledSize.height()));
@@ -83,10 +81,12 @@ void BackingStore::paint(cairo_t* context, const IntRect& rect)
 {
     ASSERT(m_backend);
 
+    cairo_save(context);
     cairo_set_operator(context, CAIRO_OPERATOR_SOURCE);
     cairo_set_source_surface(context, m_backend->surface(), 0, 0);
     cairo_rectangle(context, rect.x(), rect.y(), rect.width(), rect.height());
     cairo_fill(context);
+    cairo_restore(context);
 }
 
 void BackingStore::incorporateUpdate(ShareableBitmap* bitmap, const UpdateInfo& updateInfo)


### PR DESCRIPTION
This pull requests includes the fix from upstream, as it was backported already for WebKit2GTK+ 2.10.8 (original patch did not apply cleanly), together with a follow up patch from usptream to fix a regression introduced by it that broke transparent backgrounds.

We have backported these two patches on 2.10.2 for eos 2.6.0, but we don't have them on our 2.10.6 package because of the move from OBS to github. so we exceptionally need to do it here too.  

https://phabricator.endlessm.com/T10808
