### PR TITLE
[GTK] Fix crash when creating webview with g_object_new

### DIFF
--- a/Source/WebKit2/UIProcess/API/gtk/WebKitWebViewBase.cpp
+++ b/Source/WebKit2/UIProcess/API/gtk/WebKitWebViewBase.cpp
@@ -42,6 +42,7 @@
 #include "WebEventFactory.h"
 #include "WebFullScreenClientGtk.h"
 #include "WebInspectorProxy.h"
+#include "WebKit2Initialize.h"
 #include "WebKitAuthenticationDialog.h"
 #include "WebKitPrivate.h"
 #include "WebKitWebViewBaseAccessible.h"
@@ -1140,6 +1141,11 @@ static void webkit_web_view_base_class_init(WebKitWebViewBaseClass* webkitWebVie
     containerClass->add = webkitWebViewBaseContainerAdd;
     containerClass->remove = webkitWebViewBaseContainerRemove;
     containerClass->forall = webkitWebViewBaseContainerForall;
+
+    // Before creating a WebKitWebViewBasePriv we need to be sure that WebKit is started.
+    // Usually starting a context triggers InitializeWebKit2, but in case
+    // we create a view without asking before for a default_context we get a crash.
+    WebKit::InitializeWebKit2();
 }
 
 WebKitWebViewBase* webkitWebViewBaseCreate(WebProcessPool* context, WebPreferences* preferences, WebPageGroup* pageGroup, WebUserContentControllerProxy* userContentController, WebPageProxy* relatedPage)


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=153989

Patch by Danilo Cesar Lemes de Paula danilo.cesar@collabora.co.uk on 2016-02-08
Reviewed by Carlos Garcia Campos.

g_object_new(WEBKIT_TYPE_WEB_VIEW, NULL) crashes webkit
as _WebKitWebViewBasePrivate constructor requires a mainloop, but
webkit is only initialized when a context is created (which
doesn't happen with a direct call to g_object_new).
- UIProcess/API/gtk/WebKitWebViewBase.cpp:
  (webkit_web_view_base_class_init):

https://phabricator.endlessm.com/T10808
