### PR TITLE
Import webkit2gtk_2.16.6-1~bpo9+1 from Debian unstable

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,11 +1,79 @@
-webkit2gtk (1:2.16.2-1) eos; urgency=medium
+webkit2gtk (1:2.16.6~bpo9+1) eos; urgency=medium
 
-  * Updated to the new upstream release
+  * Updated to new upstream release
   * debian/changelog:
-    + Adding the epoch number introduced in 1:2.6.2.
-  https://phabricator.endlessm.com/T16416
+    + Adding the epoch number introduced in 1:2.6.2
+  https://phabricator.endlessm.com/T17337
 
- -- Michael Catanzaro <mcatanzaro@igalia.com>  Tue, 09 May 2017 21:26:24 -0500
+ -- Georges Basile Stavracas Neto <georges@endlessm.com>  Thu, 17 Aug 2017 23:26:19 -0300
+
+webkit2gtk (2.16.6-1~bpo9+1) stretch-backports; urgency=medium
+
+  * Rebuild for stretch-backports.
+
+ -- Alberto Garcia <berto@igalia.com>  Sat, 29 Jul 2017 21:37:20 +0300
+
+webkit2gtk (2.16.6-1) unstable; urgency=high
+
+  * New upstream release.
+  * The WebKitGTK+ security advisory WSA-2017-0006 lists the following
+    security fixes in the latest versions of WebKitGTK+:
+    + CVE-2017-7020 (fixed in 2.16.1).
+    + CVE-2017-7006, CVE-2017-7012, CVE-2017-7019, CVE-2017-7038,
+      CVE-2017-7041, CVE-2017-7042, CVE-2017-7043, CVE-2017-7049
+      (fixed in 2.16.2).
+    + CVE-2017-7011, CVE-2017-7040, CVE-2017-7059 (fixed in 2.16.3).
+    + CVE-2017-7052 (fixed in 2.16.4).
+    + CVE-2017-7018, CVE-2017-7030, CVE-2017-7034, CVE-2017-7037,
+      CVE-2017-7039, CVE-2017-7046, CVE-2017-7048, CVE-2017-7055,
+      CVE-2017-7056, CVE-2017-7061, CVE-2017-7064 (fixed in 2.16.6).
+  * debian/patches/fix-ftbfs-m68k.patch:
+    + Fix FTBFS in m68k (Closes: #868126).
+  * Override typelib-package-name-does-not-match and
+    gir-missing-typelib-dependency lintian warnings in
+    gir1.2-javascriptcoregtk-4.0, gir1.2-webkit2-4.0,
+    libjavascriptcoregtk-4.0-dev and libwebkit2gtk-4.0-dev.
+
+ -- Alberto Garcia <berto@igalia.com>  Thu, 27 Jul 2017 02:16:11 +0200
+
+webkit2gtk (2.16.5-1) unstable; urgency=medium
+
+  * New upstream release (Closes: #865772).
+
+ -- Alberto Garcia <berto@igalia.com>  Tue, 27 Jun 2017 10:29:49 +0300
+
+webkit2gtk (2.16.4-1) unstable; urgency=high
+
+  * New upstream release.
+    + This fixes CVE-2017-2538.
+
+ -- Alberto Garcia <berto@igalia.com>  Tue, 20 Jun 2017 17:24:48 +0300
+
+webkit2gtk (2.16.3-2) unstable; urgency=medium
+
+  * Upload to unstable (Closes: #836055).
+  * debian/watch:
+    + Stop scanning the 2.15 branch.
+  * debian/gbp.conf:
+    + Update upstream branch name.
+  * The WebKitGTK+ security advisory WSA-2017-0004 lists the following
+    security fixes in the latest versions of WebKitGTK+:
+    + CVE-2017-2505, CVE-2017-2508, CVE-2017-2514, CVE-2017-2521
+      (fixed in 2.16.0).
+    + CVE-2017-2504, CVE-2017-2506, CVE-2017-2515, CVE-2017-2525,
+      CVE-2017-2526, CVE-2017-2528, CVE-2017-2530, CVE-2017-2531,
+      CVE-2017-2536, CVE-2017-2544, CVE-2017-2547, CVE-2017-2549,
+      CVE-2017-6980, CVE-2017-6984 (fixed in 2.16.1).
+    + CVE-2017-2496, CVE-2017-2510, CVE-2017-2539 (fixed in 2.16.3).
+
+ -- Alberto Garcia <berto@igalia.com>  Thu, 01 Jun 2017 00:29:57 +0300
+
+webkit2gtk (2.16.3-1) experimental; urgency=medium
+
+  * New upstream release
+    + This fixes CVE-2017-2496, CVE-2017-2539 and CVE-2017-2510.
+
+ -- Alberto Garcia <berto@igalia.com>  Wed, 24 May 2017 15:17:20 +0200
 
 webkit2gtk (2.16.2-1) experimental; urgency=medium
 

--- a/debian/gbp.conf
+++ b/debian/gbp.conf
@@ -1,5 +1,5 @@
 [DEFAULT]
-debian-branch = wk2/experimental
+debian-branch = wk2/unstable
 upstream-branch = webkitgtk-2.16
 pristine-tar = False
 compression = xz

--- a/debian/gir1.2-javascriptcoregtk-4.0.lintian-overrides
+++ b/debian/gir1.2-javascriptcoregtk-4.0.lintian-overrides
@@ -1,0 +1,1 @@
+gir1.2-javascriptcoregtk-4.0: typelib-package-name-does-not-match usr/lib/*/girepository-1.0/JavaScriptCore-4.0.typelib gir1.2-javascriptcore-4.0

--- a/debian/gir1.2-webkit2-4.0.lintian-overrides
+++ b/debian/gir1.2-webkit2-4.0.lintian-overrides
@@ -1,0 +1,1 @@
+gir1.2-webkit2-4.0: typelib-package-name-does-not-match usr/lib/*/girepository-1.0/WebKit2WebExtension-4.0.typelib gir1.2-webkit2webextension-4.0

--- a/debian/libjavascriptcoregtk-4.0-dev.lintian-overrides
+++ b/debian/libjavascriptcoregtk-4.0-dev.lintian-overrides
@@ -1,0 +1,1 @@
+libjavascriptcoregtk-4.0-dev: gir-missing-typelib-dependency usr/share/gir-1.0/JavaScriptCore-4.0.gir gir1.2-javascriptcore-4.0

--- a/debian/libwebkit2gtk-4.0-dev.lintian-overrides
+++ b/debian/libwebkit2gtk-4.0-dev.lintian-overrides
@@ -1,0 +1,1 @@
+libwebkit2gtk-4.0-dev: gir-missing-typelib-dependency usr/share/gir-1.0/WebKit2WebExtension-4.0.gir gir1.2-webkit2webextension-4.0

--- a/debian/watch
+++ b/debian/watch
@@ -1,3 +1,3 @@
 version=3
 opts=pgpsigurlmangle=s/$/.asc/ \
-https://webkitgtk.org/releases/ webkitgtk-([\d]+\.[\d]*[024568]\.[\d]+).tar.xz
+https://webkitgtk.org/releases/ webkitgtk-([\d]+\.[\d]*[02468]\.[\d]+).tar.xz


### PR DESCRIPTION
The epoch was kept as part of the rebase.

https://phabricator.endlessm.com/T17337